### PR TITLE
Handle temporary redirect

### DIFF
--- a/main.py
+++ b/main.py
@@ -515,11 +515,11 @@ def __get_foil_price(api, product_id, language_id):
 
 
 def get_stock_as_array(api):
-    d = api.get_stock()['article']
+    d = api.get_stock()
 
     keys = ['idArticle', 'idProduct', 'product', 'count', 
             'price', 'isFoil', 'isSigned', 'language']  # TODO: [language][languageId]
-    stock_list = [{x: y for x, y in art.items() if x in keys} for art in d]
+    stock_list = [{x: y for x, y in article.items() if x in keys} for article in d]
     return stock_list
 
 

--- a/pymkm.py
+++ b/pymkm.py
@@ -193,7 +193,7 @@ class PyMKM:
             return r.json()
 
     def set_vacation_status(self, vacation_status=False, api=None):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Account_Vacation
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Account_Vacation
         url = '{}/account/vacation'.format(self.base_url)
         mkm_oauth = self.__setup_service(url, api)
 
@@ -219,7 +219,7 @@ class PyMKM:
             return r.json()
 
     def get_stock(self, start=None, api=None):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Stock_Management
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Stock_Management
         url = '{}/stock'.format(self.base_url)
         if (start):
             url = url + '/' + str(start)
@@ -250,7 +250,7 @@ class PyMKM:
             return r.json()['article']
 
     def add_stock(self, payload=None, api=None):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Stock_Management
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Stock_Management
         url = '{}/stock'.format(self.base_url)
 
         mkm_oauth = self.__setup_service(url, api)
@@ -266,7 +266,7 @@ class PyMKM:
             return r.json
 
     def set_stock(self, payload=None, api=None):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Stock_Management
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Stock_Management
         url = '{}/stock'.format(self.base_url)
 
         mkm_oauth = self.__setup_service(url, api)
@@ -282,7 +282,7 @@ class PyMKM:
             return r.json
 
     def delete_stock(self, payload=None, api=None):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Stock_Management
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Stock_Management
         url = '{}/stock'.format(self.base_url)
 
         mkm_oauth = self.__setup_service(url, api)
@@ -298,7 +298,7 @@ class PyMKM:
             return r.json
 
     def get_articles(self, product_id, start=0, api=None, **kwargs):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Articles
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Articles
         INCREMENT = 1000
         url = '{}/articles/{}'.format(self.base_url, product_id)
         mkm_oauth = self.__setup_service(url, api)
@@ -330,7 +330,7 @@ class PyMKM:
             raise ConnectionError(r)
 
     def find_product(self, search, api=None, **kwargs):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Find_Products
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Find_Products
 
         url = '{}/products/find'.format(self.base_url)
         mkm_oauth = self.__setup_service(url, api)
@@ -347,7 +347,7 @@ class PyMKM:
             return r.json()
 
     def find_stock_article(self, name, game_id, api=None):
-        # https://www.mkmapi.eu/ws/documentation/API_2.0:Find_Articles
+        # https://api.cardmarket.com/ws/documentation/API_2.0:Find_Articles
 
         url = '{}/stock/articles/{}/{}'.format(
             self.base_url, urllib.parse.quote(name), game_id)


### PR DESCRIPTION
Hi!

I tried using pymkm but ran into an error. If your stock exceeds 1000 items the script fails because there is no data returned, only a 307 Temporary Redirect error. This is MKM's way of telling you to use paginated requests. 

This pull request attempts to do just that. I also updated the documentation urls in the comments while I was there.

You can find the documentation regarding forced pagination [here](https://api.cardmarket.com/ws/documentation/API_2.0:Response_Codes).