### PR TITLE
Fix for unknown rarity type conversion

### DIFF
--- a/pymkm_app.py
+++ b/pymkm_app.py
@@ -486,7 +486,7 @@ class PyMkmApp:
                 }
 
     def get_rounding_limit_for_rarity(self, rarity):
-        rounding_limit = self.config['price_limit_by_rarity']['default']
+        rounding_limit = float(self.config['price_limit_by_rarity']['default'])
         try:
             rounding_limit = float(
                 self.config['price_limit_by_rarity'][rarity.lower()])


### PR DESCRIPTION
type conversion error (division by str) results if rarity not present in config. (I was trying to sell my masterpieces)