### PR TITLE
Refactored search-filter and added issue-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Context
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected result
+A clear and concise description of what you expected to happen.
+
+## Actual result
+A clear and concise description of what actually happened.
+
+## OS
+Name your OS here.
+
+## Possible Fix
+Not obligatory, but suggest fixes or reasons for the bug if they are known.
+
+## References
+If applicable, add screenshots to help explain your problem.
+Also reference the commit where this occured.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Describe a Task for this project.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Context
+A clear and concise description of what the idea is.
+
+## Alternatives
+Not obligatory. A clear and concise description of any alternative solutions or features you've considered.
+
+## References
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Should you want to avoid updating certain articles in your stock, set the starti
 ## ⚙️ Config parameters
 | Variable     | Value                                                                                                        |
 |--------------|--------------------------------------------------------------------------------------------------------------|
+| language     | Specify a language to find deals from a specific user\.                                                                          |
 | isAltered    | Determines if the card is altered\.                                                                          |
 | isSigned     | Determines if the card is signed\.                                                                           |
 | minCondition | Determines the minimal condition of a card\. \(see below for additional information\)                        |
@@ -101,7 +102,6 @@ Should you want to avoid updating certain articles in your stock, set the starti
 | LP           | Light\-played                                  |
 | PL           | Played                                         |
 | PO           | Poor                                           |
-
 
 #### idLanguage
 | ID | Language            |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,37 @@ Base prices (€) and discounts for lower grading (decimal %) can be set in `con
 
 Should you want to avoid updating certain articles in your stock, set the starting character of the comment for that article to `!` (possible to change which character in `config.json`).
 
+## ⚙️ Config parameters
+| Variable     | Value                                                                                                        |
+|--------------|--------------------------------------------------------------------------------------------------------------|
+| isAltered    | Determines if the card is altered\.                                                                          |
+| isSigned     | Determines if the card is signed\.                                                                           |
+| minCondition | Determines the minimal condition of a card\. \(see below for additional information\)                        |
+| userType     | Only articles from sellers with the specified user type are returned\. \(private, commercial, powerseller\)  |
+| idLanguage   | Only articles that match the given language are returned\. \(see below for additional information\)          |
+
+#### minCondition
+* MT - Mint
+* NM - Near Mint (default value when not specified)
+* EX - Excellent
+* GD - Good
+* LP - Light-played
+* PL - Played
+* PO - Poor
+
+#### idLanguage
+* 1 - English
+* 2 - French
+* 3 - German
+* 4 - Spanish
+* 5 - Italian
+* 6 - Simplified Chinese
+* 7 - Japanese
+* 8 - Portuguese
+* 9 - Russian
+* 10 - Korean
+* 11 - Traditional Chinese
+
 ## 📄 CSV importing
 
 If you scan cards using an app like Delver Lens or the TCG Player app, this feature can help you do bulk import of that list.

--- a/README.md
+++ b/README.md
@@ -92,26 +92,32 @@ Should you want to avoid updating certain articles in your stock, set the starti
 | idLanguage   | Only articles that match the given language are returned\. \(see below for additional information\)          |
 
 #### minCondition
-* MT - Mint
-* NM - Near Mint (default value when not specified)
-* EX - Excellent
-* GD - Good
-* LP - Light-played
-* PL - Played
-* PO - Poor
+| Abbreviation | Condition                                      |
+|--------------|------------------------------------------------|
+| MT           | Mint                                           |
+| NM           | Near Mint \(default value when not specified\) |
+| EX           | Excellent                                      |
+| GD           | Good                                           |
+| LP           | Light\-played                                  |
+| PL           | Played                                         |
+| PO           | Poor                                           |
+
 
 #### idLanguage
-* 1 - English
-* 2 - French
-* 3 - German
-* 4 - Spanish
-* 5 - Italian
-* 6 - Simplified Chinese
-* 7 - Japanese
-* 8 - Portuguese
-* 9 - Russian
-* 10 - Korean
-* 11 - Traditional Chinese
+| ID | Language            |
+|----|---------------------|
+| 1  | English             |
+| 2  | French              |
+| 3  | German              |
+| 4  | Spanish             |
+| 5  | Italian             |
+| 6  | Simplified Chinese  |
+| 7  | Japanese            |
+| 8  | Portuguese          |
+| 9  | Russian             |
+| 10 | Korean              |
+| 11 | Traditional Chinese |
+
 
 ## 📄 CSV importing
 

--- a/config_template.json
+++ b/config_template.json
@@ -23,7 +23,6 @@
     "PO": "1"
   },
   "search_filters": {
-    "language": "",
     "isAltered": false,
     "isSigned": false,
     "minCondition": "EX",

--- a/config_template.json
+++ b/config_template.json
@@ -23,6 +23,7 @@
     "PO": "1"
   },
   "search_filters": {
+    "language": "",
     "isAltered": false,
     "isSigned": false,
     "minCondition": "EX",

--- a/config_template.json
+++ b/config_template.json
@@ -9,7 +9,9 @@
     "uncommon": "0.25",
     "rare": "0.25",
     "mythic": "0.25",
-    "time shifted": "0.25"
+    "time shifted": "0.25",
+    "ultra rare": "0.25",
+    "ghost rare": "0.25"
   },
   "discount_by_condition": {
     "MT": "1",
@@ -21,7 +23,12 @@
     "PO": "1"
   },
   "search_filters": {
-    "language": ""
+    "language": "",
+    "isAltered": false,
+    "isSigned": false,
+    "minCondition": "EX",
+    "userType": "",
+    "idLanguage": 1
   },
   "reporting": true,
   "sticky_price_char": "!",

--- a/pymkm/pymkm_app.py
+++ b/pymkm/pymkm_app.py
@@ -334,7 +334,7 @@ class PyMkmApp:
         else:
             filtered_articles = [x for x in result if x.get("price") > 1]
             # language from configured filter
-            language_filter_string = self.config["search_filters"]["idLanguage"]
+            language_filter_string = self.config["search_filters"]["language"]
             if language_filter_string:
                 language_filter_code = api.get_language_code_from_string(
                     language_filter_string

--- a/pymkm/pymkm_app.py
+++ b/pymkm/pymkm_app.py
@@ -812,15 +812,24 @@ class PyMkmApp:
         # TODO: Add support for card condition
         account = self.account
         country_code = account["country"]
+
+        config = self.config
+        is_altered = config["search_filters"]["isAltered"]
+        is_signed = config["search_filters"]["isSigned"]
+        min_condition = config["search_filters"]["minCondition"]
+        user_type = config["search_filters"]["userType"]
+        id_language = config["search_filters"]["idLanguage"]
+
         articles = api.get_articles(
             product_id,
             **{
                 "isFoil": str(is_foil).lower(),
-                "isAltered": "false",
-                "isSigned": "false",
-                "minCondition": "EX",
+                "isAltered": is_altered,
+                "isSigned": is_signed,
+                "minCondition": min_condition,
                 "country": country_code,
-                "idLanguage": 1,
+                "userType": user_type,
+                "idLanguage": id_language,
             },
         )
         table_data = []

--- a/pymkm/pymkm_app.py
+++ b/pymkm/pymkm_app.py
@@ -334,7 +334,7 @@ class PyMkmApp:
         else:
             filtered_articles = [x for x in result if x.get("price") > 1]
             # language from configured filter
-            language_filter_string = self.config["search_filters"]["language"]
+            language_filter_string = self.config["search_filters"]["idLanguage"]
             if language_filter_string:
                 language_filter_code = api.get_language_code_from_string(
                     language_filter_string

--- a/pymkm/pymkmapi.py
+++ b/pymkm/pymkmapi.py
@@ -114,7 +114,6 @@ class PyMkmApi:
             self.logger.debug(">> Attribute not found in header: {}".format(err))
 
     def __setup_service(self, url, provided_oauth):
-        oauth = None
         if provided_oauth is not None:
             return provided_oauth
         else:
@@ -173,7 +172,7 @@ class PyMkmApi:
         # For item i in a range that is a length of l,
         for i in range(0, len(l), n):
             # Create an index range for l of n items:
-            yield l[i : i + n]
+            yield l[i: i + n]
 
     def get_games(self, provided_oauth=None):
         url = "{}/games".format(self.base_url)
@@ -271,13 +270,13 @@ class PyMkmApi:
         if self.__handle_response(r):
             return r.json()
 
-    def set_display_language(self, display_langauge=1, provided_oauth=None):
+    def set_display_language(self, display_language=1, provided_oauth=None):
         # 1: English, 2: French, 3: German, 4: Spanish, 5: Italian
         url = "{}/account/language".format(self.base_url)
         mkm_oauth = self.__setup_service(url, provided_oauth)
 
-        self.logger.debug(">> Setting display language to: " + str(display_langauge))
-        r = mkm_oauth.put(url, params={"idDisplayLanguage": display_langauge})
+        self.logger.debug(">> Setting display language to: " + str(display_language))
+        r = mkm_oauth.put(url, params={"idDisplayLanguage": display_language})
 
         if self.__handle_response(r):
             return r.json()

--- a/pymkm/pymkmapi.py
+++ b/pymkm/pymkmapi.py
@@ -43,7 +43,7 @@ class PyMkmApi:
         "Italian",
         "S-Chinese",
         "Japanese",
-        "Portugese",
+        "Portuguese",
         "Russian",
         "Korean",
         "T-Chinese",

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -502,7 +502,12 @@ Dragon Breath,Scourge,1,Foil,French"""
                     "PO": "0.4"
                 },
                 "search_filters": {
-                    "language": ""
+                    "language": "",
+                    "isAltered": false,
+                    "isSigned": false,
+                    "minCondition": "EX",
+                    "userType": "",
+                    "idLanguage": 1
                 },
                 "sticky_price_char": "!",
                 "uuid": "xxx",


### PR DESCRIPTION
# Description
I refactored the search-filters inside `get_competition(...)` and moved them to the config-file.
In addition to that i described the different config parameters inside the README to make it easier for non-programmers to configure. Furthermore a friend of mine requested a parameter to undercut commercial sellers only. That's the reason why i added `userType` to the config-file. 

The `find_deals_from_user(...)`-function could be refactored to match the `idLanguage`-param inside the config instead of using an own parameter `language`. 

### Code
- Created Issue-Templates to help users create Bug-Reports
- Added 2 new Yu-Gi-Oh!-Rarities

## Types of changes
- Enhancement
- Documentation 

## Reference
- [idLanguage](https://api.cardmarket.com/ws/documentation/API_2.0:Stock)
